### PR TITLE
Fixed java.text.ParseException: Unparseable date in Book.java

### DIFF
--- a/src/main/java/org/openaudible/books/Book.java
+++ b/src/main/java/org/openaudible/books/Book.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 public class Book implements Comparable<Book>, Serializable {
 	static SimpleDateFormat audibleDateFormat = new SimpleDateFormat("dd-MMM-yyyy", Locale.ENGLISH);
 	static SimpleDateFormat purchaseDateFormat = new SimpleDateFormat("MM-dd-yyyy", Locale.ENGLISH);
-	static SimpleDateFormat displayFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
+	static SimpleDateFormat displayDateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
 	private final HashMap<String, String> map = new HashMap<>();
 	
 	public Book(HashMap<String, String> m) {
@@ -290,7 +290,7 @@ public class Book implements Comparable<Book>, Serializable {
 	}
 	
 	public void setPurchaseDate(Date d) {
-		String s = displayFormat.format(d);
+		String s = displayDateFormat.format(d);
 		setPurchaseDate(s);
 	}
 	
@@ -310,7 +310,7 @@ public class Book implements Comparable<Book>, Serializable {
 			
 			try {
 				Date d = audibleDateFormat.parse(date);
-				String out = displayFormat.format(d);
+				String out = displayDateFormat.format(d);
 				return out;
 			} catch (ParseException e) {
 				e.printStackTrace();

--- a/src/main/java/org/openaudible/books/Book.java
+++ b/src/main/java/org/openaudible/books/Book.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 public class Book implements Comparable<Book>, Serializable {
 	static SimpleDateFormat audibleDateFormat = new SimpleDateFormat("dd-MMM-yyyy", Locale.ENGLISH);
 	static SimpleDateFormat purchaseDateFormat = new SimpleDateFormat("MM-dd-yyyy", Locale.ENGLISH);
-	static SimpleDateFormat dispalyFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
+	static SimpleDateFormat displayFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
 	private final HashMap<String, String> map = new HashMap<>();
 	
 	public Book(HashMap<String, String> m) {
@@ -290,7 +290,7 @@ public class Book implements Comparable<Book>, Serializable {
 	}
 	
 	public void setPurchaseDate(Date d) {
-		String s = dispalyFormat.format(d);
+		String s = displayFormat.format(d);
 		setPurchaseDate(s);
 	}
 	
@@ -310,7 +310,7 @@ public class Book implements Comparable<Book>, Serializable {
 			
 			try {
 				Date d = audibleDateFormat.parse(date);
-				String out = dispalyFormat.format(d);
+				String out = displayFormat.format(d);
 				return out;
 			} catch (ParseException e) {
 				e.printStackTrace();

--- a/src/main/java/org/openaudible/books/Book.java
+++ b/src/main/java/org/openaudible/books/Book.java
@@ -8,11 +8,12 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 
 public class Book implements Comparable<Book>, Serializable {
-	static SimpleDateFormat audibleDateFormat = new SimpleDateFormat("dd-MMM-yyyy");
-	static SimpleDateFormat purchaseDateFormat = new SimpleDateFormat("MM-dd-yyyy");
-	static SimpleDateFormat dispalyFormat = new SimpleDateFormat("yyyy-MM-dd");
+	static SimpleDateFormat audibleDateFormat = new SimpleDateFormat("dd-MMM-yyyy", Locale.ENGLISH);
+	static SimpleDateFormat purchaseDateFormat = new SimpleDateFormat("MM-dd-yyyy", Locale.ENGLISH);
+	static SimpleDateFormat dispalyFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
 	private final HashMap<String, String> map = new HashMap<>();
 	
 	public Book(HashMap<String, String> m) {


### PR DESCRIPTION
OpenAudible threw the following error on startup in debugging mode:

```
java.text.ParseException: Unparseable date: "21-OCT-2013"
	at java.text.DateFormat.parse(DateFormat.java:366)
	at org.openaudible.books.Book.getReleaseDateSortable(Book.java:311)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:163)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.getColumnDisplayable(EnumTable.java:433)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:133)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setTableItems(EnumTable.java:242)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:75)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable._populateDataGUI(EnumTable.java:282)
	at org.openaudible.desktop.swt.gui.tables.EnumTable$1.task(EnumTable.java:298)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:121)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.populateData(EnumTable.java:293)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setItems(EnumTable.java:169)
	at org.openaudible.desktop.swt.manager.views.BookTable$1.task(BookTable.java:103)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.eclipse.swt.widgets.RunnableLock.run(Unknown Source)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Unknown Source)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.block(ModalContext.java:158)
	at org.eclipse.jface.operation.ModalContext.run(ModalContext.java:326)
	at org.eclipse.jface.dialogs.ProgressMonitorDialog.run(ProgressMonitorDialog.java:495)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.runTask(ProgressDialog.java:328)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog$1.task(ProgressDialog.java:138)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.slow(SWTAsync.java:136)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:127)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:123)
	at org.openaudible.desktop.swt.manager.AudibleGUI.applicationStarted(AudibleGUI.java:934)
	at org.openaudible.desktop.swt.manager.Application.applicationStarted(Application.java:77)
	at org.openaudible.desktop.swt.gui.GUI.run(GUI.java:426)
	at org.openaudible.desktop.swt.manager.AppLoader.<init>(AppLoader.java:54)
	at org.openaudible.desktop.swt.manager.AppLoader.main(AppLoader.java:62)
	at org.openaudible.desktop.Application.main(Application.java:19)
java.text.ParseException: Unparseable date: "19-MAY-2015"
	at java.text.DateFormat.parse(DateFormat.java:366)
	at org.openaudible.books.Book.getReleaseDateSortable(Book.java:311)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:163)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.getColumnDisplayable(EnumTable.java:433)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:133)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setTableItems(EnumTable.java:242)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:75)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable._populateDataGUI(EnumTable.java:282)
	at org.openaudible.desktop.swt.gui.tables.EnumTable$1.task(EnumTable.java:298)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:121)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.populateData(EnumTable.java:293)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setItems(EnumTable.java:169)
	at org.openaudible.desktop.swt.manager.views.BookTable$1.task(BookTable.java:103)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.eclipse.swt.widgets.RunnableLock.run(Unknown Source)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Unknown Source)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.block(ModalContext.java:158)
	at org.eclipse.jface.operation.ModalContext.run(ModalContext.java:326)
	at org.eclipse.jface.dialogs.ProgressMonitorDialog.run(ProgressMonitorDialog.java:495)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.runTask(ProgressDialog.java:328)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog$1.task(ProgressDialog.java:138)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.slow(SWTAsync.java:136)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:127)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:123)
	at org.openaudible.desktop.swt.manager.AudibleGUI.applicationStarted(AudibleGUI.java:934)
	at org.openaudible.desktop.swt.manager.Application.applicationStarted(Application.java:77)
	at org.openaudible.desktop.swt.gui.GUI.run(GUI.java:426)
	at org.openaudible.desktop.swt.manager.AppLoader.<init>(AppLoader.java:54)
	at org.openaudible.desktop.swt.manager.AppLoader.main(AppLoader.java:62)
	at org.openaudible.desktop.Application.main(Application.java:19)
java.text.ParseException: Unparseable date: "18-OCT-2016"
	at java.text.DateFormat.parse(DateFormat.java:366)
	at org.openaudible.books.Book.getReleaseDateSortable(Book.java:311)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:163)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.getColumnDisplayable(EnumTable.java:433)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:133)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setTableItems(EnumTable.java:242)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:75)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable._populateDataGUI(EnumTable.java:282)
	at org.openaudible.desktop.swt.gui.tables.EnumTable$1.task(EnumTable.java:298)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:121)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.populateData(EnumTable.java:293)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setItems(EnumTable.java:169)
	at org.openaudible.desktop.swt.manager.views.BookTable$1.task(BookTable.java:103)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.eclipse.swt.widgets.RunnableLock.run(Unknown Source)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Unknown Source)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.block(ModalContext.java:158)
	at org.eclipse.jface.operation.ModalContext.run(ModalContext.java:326)
	at org.eclipse.jface.dialogs.ProgressMonitorDialog.run(ProgressMonitorDialog.java:495)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.runTask(ProgressDialog.java:328)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog$1.task(ProgressDialog.java:138)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.slow(SWTAsync.java:136)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:127)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:123)
	at org.openaudible.desktop.swt.manager.AudibleGUI.applicationStarted(AudibleGUI.java:934)
	at org.openaudible.desktop.swt.manager.Application.applicationStarted(Application.java:77)
	at org.openaudible.desktop.swt.gui.GUI.run(GUI.java:426)
	at org.openaudible.desktop.swt.manager.AppLoader.<init>(AppLoader.java:54)
	at org.openaudible.desktop.swt.manager.AppLoader.main(AppLoader.java:62)
	at org.openaudible.desktop.Application.main(Application.java:19)
java.text.ParseException: Unparseable date: "21-OCT-2013"
	at java.text.DateFormat.parse(DateFormat.java:366)
	at org.openaudible.books.Book.getReleaseDateSortable(Book.java:311)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:163)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.getColumnDisplayable(EnumTable.java:433)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:133)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setTableItems(EnumTable.java:242)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:75)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable._populateDataGUI(EnumTable.java:282)
	at org.openaudible.desktop.swt.gui.tables.EnumTable$1.task(EnumTable.java:298)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:121)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.populateData(EnumTable.java:293)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setItems(EnumTable.java:169)
	at org.openaudible.desktop.swt.manager.views.BookTable$1.task(BookTable.java:103)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.eclipse.swt.widgets.RunnableLock.run(Unknown Source)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Unknown Source)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.block(ModalContext.java:158)
	at org.eclipse.jface.operation.ModalContext.run(ModalContext.java:326)
	at org.eclipse.jface.dialogs.ProgressMonitorDialog.run(ProgressMonitorDialog.java:495)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.runTask(ProgressDialog.java:328)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog$1.task(ProgressDialog.java:138)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.slow(SWTAsync.java:136)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:127)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:123)
	at org.openaudible.desktop.swt.manager.AudibleGUI.applicationStarted(AudibleGUI.java:934)
	at org.openaudible.desktop.swt.manager.Application.applicationStarted(Application.java:77)
	at org.openaudible.desktop.swt.gui.GUI.run(GUI.java:426)
	at org.openaudible.desktop.swt.manager.AppLoader.<init>(AppLoader.java:54)
	at org.openaudible.desktop.swt.manager.AppLoader.main(AppLoader.java:62)
	at org.openaudible.desktop.Application.main(Application.java:19)
java.text.ParseException: Unparseable date: "19-MAY-2015"
	at java.text.DateFormat.parse(DateFormat.java:366)
	at org.openaudible.books.Book.getReleaseDateSortable(Book.java:311)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:163)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.getColumnDisplayable(EnumTable.java:433)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:133)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setTableItems(EnumTable.java:242)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:75)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable._populateDataGUI(EnumTable.java:282)
	at org.openaudible.desktop.swt.gui.tables.EnumTable$1.task(EnumTable.java:298)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:121)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.populateData(EnumTable.java:293)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setItems(EnumTable.java:169)
	at org.openaudible.desktop.swt.manager.views.BookTable$1.task(BookTable.java:103)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.eclipse.swt.widgets.RunnableLock.run(Unknown Source)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Unknown Source)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.block(ModalContext.java:158)
	at org.eclipse.jface.operation.ModalContext.run(ModalContext.java:326)
	at org.eclipse.jface.dialogs.ProgressMonitorDialog.run(ProgressMonitorDialog.java:495)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.runTask(ProgressDialog.java:328)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog$1.task(ProgressDialog.java:138)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.slow(SWTAsync.java:136)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:127)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:123)
	at org.openaudible.desktop.swt.manager.AudibleGUI.applicationStarted(AudibleGUI.java:934)
	at org.openaudible.desktop.swt.manager.Application.applicationStarted(Application.java:77)
	at org.openaudible.desktop.swt.gui.GUI.run(GUI.java:426)
	at org.openaudible.desktop.swt.manager.AppLoader.<init>(AppLoader.java:54)
	at org.openaudible.desktop.swt.manager.AppLoader.main(AppLoader.java:62)
	at org.openaudible.desktop.Application.main(Application.java:19)
java.text.ParseException: Unparseable date: "18-OCT-2016"
	at java.text.DateFormat.parse(DateFormat.java:366)
	at org.openaudible.books.Book.getReleaseDateSortable(Book.java:311)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:163)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnComparable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.getColumnDisplayable(EnumTable.java:433)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:133)
	at org.openaudible.desktop.swt.manager.views.BookTable.getColumnDisplayable(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setTableItems(EnumTable.java:242)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:75)
	at org.openaudible.desktop.swt.manager.views.BookTable.setTableItems(BookTable.java:24)
	at org.openaudible.desktop.swt.gui.tables.EnumTable._populateDataGUI(EnumTable.java:282)
	at org.openaudible.desktop.swt.gui.tables.EnumTable$1.task(EnumTable.java:298)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:121)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.populateData(EnumTable.java:293)
	at org.openaudible.desktop.swt.gui.tables.EnumTable.setItems(EnumTable.java:169)
	at org.openaudible.desktop.swt.manager.views.BookTable$1.task(BookTable.java:103)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.eclipse.swt.widgets.RunnableLock.run(Unknown Source)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Unknown Source)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Unknown Source)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.block(ModalContext.java:158)
	at org.eclipse.jface.operation.ModalContext.run(ModalContext.java:326)
	at org.eclipse.jface.dialogs.ProgressMonitorDialog.run(ProgressMonitorDialog.java:495)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.runTask(ProgressDialog.java:328)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog$1.task(ProgressDialog.java:138)
	at org.openaudible.desktop.swt.gui.SWTAsync.run(SWTAsync.java:184)
	at org.openaudible.desktop.swt.gui.SWTAsync.slow(SWTAsync.java:136)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:127)
	at org.openaudible.desktop.swt.gui.progress.ProgressDialog.doProgressTask(ProgressDialog.java:123)
	at org.openaudible.desktop.swt.manager.AudibleGUI.applicationStarted(AudibleGUI.java:934)
	at org.openaudible.desktop.swt.manager.Application.applicationStarted(Application.java:77)
	at org.openaudible.desktop.swt.gui.GUI.run(GUI.java:426)
	at org.openaudible.desktop.swt.manager.AppLoader.<init>(AppLoader.java:54)
	at org.openaudible.desktop.swt.manager.AppLoader.main(AppLoader.java:62)
	at org.openaudible.desktop.Application.main(Application.java:19)
```

Adding `Locale.ENGLISH` to the SimpleDateFormats fixed this bug for me (hopefully it does not break it for others^^).

Before:
![8f596d559c8ed8a515bcd8f6bb0e9b5c](https://user-images.githubusercontent.com/29959150/53195563-2df93d00-3616-11e9-8c08-59b615a6329b.png)

After:
![b043f2910e1709a5011e1336f76ab148](https://user-images.githubusercontent.com/29959150/53195553-2a65b600-3616-11e9-9235-9498694aeff4.png)

Currently this what my downloaded software (release) looks like:
![image](https://user-images.githubusercontent.com/29959150/53199215-c1367080-361e-11e9-8a8a-4a2ead0287da.png)

Furthermore I fixed a small typo and renamed a variable in the same file.