### PR TITLE
Added JAXB maven dependency to pom.xml to allow build from source on ubuntu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,5 +235,21 @@
             <artifactId>opencsv</artifactId>
             <version>3.7</version>
         </dependency>
+
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>2.3.0</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
+          <version>2.3.0</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+          <version>2.3.0</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Build failed with a load of JAXB package dependency errors. Added dependencies in the pom.xml as recommended by this [stackoverflow post](https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist), dependencies now found and builds fine.

Origional error messages:
```
INFO] 100 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.919 s
[INFO] Finished at: 2019-06-01T13:08:36+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project openaudible: Compilation failure: Compilation failure: 
[ERROR] /home/david/bin/openaudible/src/main/java/org/semper/reformanda/syndication/rss/itunes/ItunesImage.java:[19,33] package javax.xml.bind.annotation does not exist
[ERROR] /home/david/bin/openaudible/src/main/java/org/semper/reformanda/syndication/util/MimeTypeAdapter.java:[21,42] package javax.xml.bind.annotation.adapters does not exist
[ERROR] /home/david/bin/openaudible/src/main/java/org/semper/reformanda/syndication/util/MimeTypeAdapter.java:[23,38] cannot find symbol
[ERROR]   symbol: class XmlAdapter
[ERROR] /home/david/bin/openaudible/src/main/java/org/openaudible/feeds/rss/CreateRSS.java:[7,22] package javax.xml.bind does not exist
[ERROR] /home/david/bin/openaudible/src/main/java/org/openaudible/feeds/rss/CreateRSS.java:[8,22] package javax.xml.bind does not exist
[ERROR] /home/david/bin/openaudible/src/main/java/org/semper/reformanda/syndication/rss/Item.java:[26,33] package javax.xml.bind.annotation does not exist
[ERROR] /home/david/bin/openaudible/src/main/java/org/semper/reformanda/syndication/rss/Item.java:[27,42] package javax.xml.bind.annotation.adapters does not exist
...
```